### PR TITLE
Use CRAFT_TARGET_ARCH to set which arch to build

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -32,5 +32,5 @@ parts:
     build-snaps:
       - go/1.21/stable
     override-build: |
-      make
+      make ARCH=${CRAFT_TARGET_ARCH}
       cp $CRAFT_PART_BUILD/metrics-server $CRAFT_PART_INSTALL


### PR DESCRIPTION
### Details

Discovered the arm64 images didn't run b/c although pebble was arm64, the metrics server binary wasn't

### Overview
Use [CRAFT_TARGET_ARCH](https://documentation.ubuntu.com/rockcraft/en/latest/reference/parts_steps/#step-execution-environment) to set the architecture for the build during the rockcraft build stage.