### PR TITLE
feat: metrics-server fips rock 0.8.0

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,7 +16,12 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
+      enabled-ubuntu-pro-features: "fips-updates"
+      multipass-image: "22.04"
+      rockcraft-revisions: '{"amd64": "3494"}'
+    secrets:
+      UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/0.8.0/rockcraft.yaml
+++ b/0.8.0/rockcraft.yaml
@@ -1,0 +1,36 @@
+name: metrics-server
+summary: ROCK for the metrics-server Project.
+description: This ROCK is a drop in replacement for the metrics-server/metrics-server image.
+version: "0.8.0"
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+services:
+  metrics-server:
+    override: replace
+    summary: "metrics-server service"
+    startup: enabled
+    command: "/metrics-server [ ]"
+    on-failure: shutdown
+
+entrypoint-service: metrics-server
+
+parts:
+  metrics-server:
+    plugin: nil
+    source: https://github.com/kubernetes-sigs/metrics-server.git
+    source-type: git
+    source-tag: v0.8.0
+    source-depth: 1
+    build-packages:
+      - build-essential
+    build-snaps:
+      - go/1.24-fips/stable
+    override-build: |
+      CGO_ENABLED=1 make SYSTEM="GOTOOLCHAIN=local GOEXPERIMENT=opensslcrypto" ARCH=${CRAFT_TARGET_ARCH}
+      cp $CRAFT_PART_BUILD/metrics-server $CRAFT_PART_INSTALL

--- a/0.8.0/rockcraft.yaml
+++ b/0.8.0/rockcraft.yaml
@@ -31,6 +31,10 @@ parts:
       - build-essential
     build-snaps:
       - go/1.24-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     override-build: |
       CGO_ENABLED=1 make SYSTEM="GOTOOLCHAIN=local GOEXPERIMENT=opensslcrypto" ARCH=${CRAFT_TARGET_ARCH}
       cp $CRAFT_PART_BUILD/metrics-server $CRAFT_PART_INSTALL

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,62 @@
+## Overview
+This document provides an analysis of metric server's cryptographic implementation
+with respect to FIPS 140 compliance requirements.
+
+## FIPS Compliance Status
+
+Metrics-server uses both standard Go `crypto` and the extended `https://pkg.go.dev/golang.org/x/crypto` modules. To address the FIPS compliance for the standard package, the following steps are required:
+
+1. **Go Toolchain**: Must use the modified [Go toolchain from Microsoft](https://github.com/microsoft/go/blob/microsoft/release-branch.go1.24/eng/doc/fips/README.md) that links against FIPS-validated cryptographic modules.
+2. **OpenSSL**: Must link against a FIPS-validated OpenSSL implementation, e.g. from `core22/fips`.
+3. **Build Environment**: Must be built on an Ubuntu Pro machine with FIPS updates enabled, see below.
+
+For the extended module, enduring the non-approved algorithms are not executed would suffice.  
+
+## Manual build and test
+
+To manually build the fips-compliant rock image you need an Ubuntu Pro token. Once obtained, you can follow these intructions:
+
+- Install multipass on a machine with enabled virtualization capabilities:
+
+```
+sudo snap install multipass
+```
+
+- Launch a builder instance with an attached Ubuntu Pro account:
+
+```
+cat <<EOF | multipass launch --name rock-builder --cloud-init - --cpus 4 --disk 20GB --memory 8GB 22.04
+package_update: true
+package_upgrade: true
+packages:
+- ubuntu-advantage-tools
+runcmd:
+- pro attach <UBUNTU_PRO_TOKEN> --no-auto-enable
+- reboot
+EOF
+```
+
+- Install rockcraft from the `edge/pro-sources` channel
+
+```
+multipass exec rock-builder -- sudo snap install rockcraft --channel=edge/pro-sources --classic
+
+```
+- Initialize `lxd` on the machine 
+```
+
+multipass exec rock-builder -- lxd init --auto
+
+```
+
+- Switch to the directory where you `rockcraft.yaml` file is located and mount the directory on Multipass instance
+
+```
+multipass mount . rock-builder:/home/ubuntu/rock
+```
+
+- Pack the rock image with the `fips-updates` service enabled on both the build environment and the rock
+
+```
+multipass exec rock-builder -d /home/ubuntu/rock -- sudo rockcraft pack --pro=fips-updates
+```


### PR DESCRIPTION
## feat: metrics-server fips rock 0.8.0

This PR adds a fips enabled rock for metrics-server.

Previous image:
```
Digest: sha256:2b94444cf67479f2fe77e353f64d04aab98a222c057cd40b2000aff9a2fb1682
ghcr.io/canonical/metrics-server:0.7.2-ck0
```

Additionally, tested in k8s cluster with and without FIPS enabled:
```
ubuntu@juju-16469f-0:~$ sudo cat /proc/sys/crypto/fips_enabled
1
ubuntu@juju-16469f-0:~$ sudo k8s kubectl get po -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS        AGE
kube-system   cilium-m46vf                          1/1     Running   1 (3h25m ago)   4h22m
kube-system   cilium-operator-75bc49fc7f-dr4f4      1/1     Running   1 (3h25m ago)   4h22m
kube-system   ck-storage-rawfile-csi-controller-0   2/2     Running   2 (3h25m ago)   4h22m
kube-system   ck-storage-rawfile-csi-node-txvcc     4/4     Running   4 (3h25m ago)   4h22m
kube-system   coredns-fc9c778db-f5fc8               1/1     Running   1 (3h25m ago)   4h22m
kube-system   metrics-server-98fb84d5-rqqm5         1/1     Running   0               13m

ubuntu@juju-16469f-0:~$ sudo k8s kubectl top po -A
NAMESPACE     NAME                                  CPU(cores)   MEMORY(bytes)   
kube-system   cilium-m46vf                          76m          465Mi           
kube-system   cilium-operator-75bc49fc7f-dr4f4      6m           49Mi            
kube-system   ck-storage-rawfile-csi-controller-0   2m           43Mi            
kube-system   ck-storage-rawfile-csi-node-txvcc     6m           60Mi            
kube-system   coredns-fc9c778db-f5fc8               3m           15Mi            
kube-system   metrics-server-98fb84d5-rqqm5         3m           20Mi     
       
ubuntu@juju-16469f-0:~$ sudo k8s kubectl describe po metrics-server-98fb84d5-rqqm5 -n kube-system | grep ghcr
    Image:           ghcr.io/canonical/metrics-server:768d283354582a82553cfcdf3e9421ba5cd752d04b5fc31a0c7a8d31321462ab-amd64
```
