### PR TITLE
feat: Make 0.7.2 FIPS compliant

### DIFF
--- a/0.7.2/rockcraft.yaml
+++ b/0.7.2/rockcraft.yaml
@@ -30,7 +30,11 @@ parts:
     build-packages:
       - build-essential
     build-snaps:
-      - go/1.22/stable
+      - go/1.24-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     override-build: |
-      make ARCH=${CRAFT_TARGET_ARCH}
+      CGO_ENABLED=1 make SYSTEM="GOTOOLCHAIN=local GOEXPERIMENT=opensslcrypto" ARCH=${CRAFT_TARGET_ARCH}
       cp $CRAFT_PART_BUILD/metrics-server $CRAFT_PART_INSTALL


### PR DESCRIPTION
### Overview

This PR makes 0.7.2 FIPS compliant. This is inspired by https://github.com/canonical/metrics-server-rock/pull/9, but since we're actually using 0.7.2 in the k8s-snap, we need to make this version FIPS compliant as well.

Without this, metrics-server rock fails to start with a `exec /bin/pebble: no such file or directory` error.

- Go channel is updated to use the one with the FIPS changes
- Uses core22 from the FIPS channel
- Provides certain environment variables for Go in order to build a FIPS-compliant binary

The other changes are also necessary since we're using a specific rockcraft revision (changed in the original PR)