### PR TITLE
ci: use latest/edge rockcraft channel and force-build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -21,7 +21,6 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -33,7 +33,7 @@ jobs:
     permissions:
       security-events: write
       packages: read
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -42,7 +42,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -18,7 +18,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
+      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,13 +22,13 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -37,7 +37,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
@@ -28,6 +31,9 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
+    permissions:
+      security-events: write
+      packages: read
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit

--- a/0.7.1/.rockcraft-version.yaml
+++ b/0.7.1/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/0.7.2/.rockcraft-version.yaml
+++ b/0.7.2/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/0.8.0/.rockcraft-version.yaml
+++ b/0.8.0/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge


### PR DESCRIPTION
## Summary
- Replace the repo-wide rockcraft revision pin (`3494`/`3547`) with a per-version `X.Y.Z/.rockcraft-version.yaml` selecting the `latest/edge` channel for all rocks (`0.7.1`, `0.7.2`, `0.8.0`).
- Switch the `build_rocks.yaml` workflow to the `fix-lxd-guest-pro-attach` ref and enable `force-build: true`.

## Why
Mirrors the approach taken in [cilium-rocks#59](https://github.com/canonical/cilium-rocks/pull/59). The shared build workflow's rockcraft resolution walks the rock directory and its immediate parent, so placing `.rockcraft-version.yaml` inside each version directory makes the channel selection effective per-rock. Moving from a pinned rockcraft revision to `latest/edge` picks up newer rockcraft handling of the FIPS apt-overlay (which resolves a deterministic FIPS build failure caused by package downgrades), and `force-build` ensures the rocks are rebuilt.

## Notes
- The other jobs (`run-tests`, `scan-images`, `build-and-push-multiarch-manifest`) keep their pinned `@6b24c265…` SHA — only the build ref changed, matching the scope of the cilium PR.
- No `dlv`/delve or `PEBBLE_VERSION` test changes are needed here: this repo has no delve part and its sanity test does not assert a pebble version. The FIPS pebble is pulled in automatically via the newer `latest/edge` rockcraft.
