### PR TITLE
ci: grant packages:write to multiarch manifest job

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -42,6 +42,9 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}


### PR DESCRIPTION
## Summary

Applies the same fix as canonical/cilium-rocks#62, canonical/metallb-rocks#40, and canonical/coredns-rock#89 to prevent the `Combine Rocks and Push Multiarch Manifest` job from failing on push-to-`main` runs with:

```
failed to put manifest ghcr.io/canonical/metrics-server...: denied: installation not allowed to Write organization package
```

## Root cause

The `build-and-push-multiarch-manifest` job calls the reusable `assemble_multiarch_image.yaml` workflow, which logs into `ghcr.io` and pushes the multiarch manifest using `GITHUB_TOKEN`. The job had **no `permissions:` block**, and with no workflow-level default the token fell back to `packages: read`. `docker login` succeeds (read is enough), but the `docker manifest push` requires `packages: write`, so it is denied.

This only surfaces on `push` events because the job pushes only when `dry-run: false` (`github.event_name == 'push'`); PR runs are dry-run and never push.

The sibling `build-and-push-arch-specifics` job already sets `contents: read` / `packages: write`, but that was never applied to the manifest job which also pushes to `ghcr.io`.

## Change

Add a `permissions:` block (`contents: read`, `packages: write`) to the `build-and-push-multiarch-manifest` job, mirroring the arch-specific build job.

## Verification

Not reproducible locally (org-level Actions token permissions). After merge, the next push-to-`main` run's token-permissions group should show `Packages: write` and the manifest push should succeed.